### PR TITLE
Implementation of the Auxiliary histograms

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -39,10 +39,11 @@ else:
 
 logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
-procfilt = ['Wplusmunu', 'Wminusmunu'] if args.addHelicityHistos else args.filterProcs 
+#procfilt = ['Wplusmunu', 'Wminusmunu'] if args.addHelicityHistos else args.filterProcs 
 
 datasets = wremnants.datasets2016.getDatasets(maxFiles=args.maxFiles,
-                                              filt=procfilt,
+                                              #filt=procfilt,
+                                              filt=args.filterProcs,
                                               excl=args.excludeProcs, 
                                               nanoVersion="v8" if args.v8 else "v9", base_path=args.dataPath)
 
@@ -213,7 +214,7 @@ def build_graph(df, dataset):
     require_prompt = "tau" not in dataset.name # for muon GEN-matching   
     
     # disable auxiliary histograms when unfolding to reduce memory consumptions
-    auxiliary_histograms = not args.unfolding
+    auxiliary_histograms = not args.unfolding and not args.addHelicityHistos
 
     apply_theory_corr = args.theoryCorr and dataset.name in corr_helpers
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -39,10 +39,8 @@ else:
 
 logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
-#procfilt = ['Wplusmunu', 'Wminusmunu'] if args.addHelicityHistos else args.filterProcs 
 
 datasets = wremnants.datasets2016.getDatasets(maxFiles=args.maxFiles,
-                                              #filt=procfilt,
                                               filt=args.filterProcs,
                                               excl=args.excludeProcs, 
                                               nanoVersion="v8" if args.v8 else "v9", base_path=args.dataPath)


### PR DESCRIPTION
In the unfolding case, auxiliary histograms were removed. These are very large histograms needed for the fake studies. These histograms are not needed for the "ASYMOW" analysis.

Removed them in same way, as was done for the unfolding case