### PR TITLE
Updates for 2018

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -55,7 +55,8 @@ thisAnalysis = ROOT.wrem.AnalysisType.Wmass
 datasets = getDatasets(maxFiles=args.maxFiles,
                        filt=args.filterProcs,
                        excl=args.excludeProcs, 
-                       nanoVersion="v8" if args.v8 else "v9", base_path=args.dataPath, oneMCfileEveryN=args.oneMCfileEveryN)
+                       nanoVersion="v8" if args.v8 else "v9", base_path=args.dataPath, oneMCfileEveryN=args.oneMCfileEveryN,
+                       dataYear=args.dataYear)
 
 era = args.era
 
@@ -141,8 +142,9 @@ else:
 
 logger.info(f"SF file: {args.sfFile}")
 
-pileup_helper = wremnants.make_pileup_helper(era = era)
-vertex_helper = wremnants.make_vertex_helper(era = era)
+##Fixme later..PU helper is now default for 2018
+pileup_helper = wremnants.make_pileup_helper(era = era) if args.dataYear == 2016 else wremnants.make_pileup_helperRun2()
+vertex_helper = wremnants.make_vertex_helper(era = era) if args.dataYear == 2016 else wremnants.make_vertex_helper(str(args.dataYear), filename=common.data_dir+ f"/vertex/vertexPileupWeights_{args.dataYear}.root")
 
 calib_filepaths = common.calib_filepaths
 closure_filepaths = common.closure_filepaths
@@ -255,7 +257,8 @@ def build_graph(df, dataset):
 
     if not args.makeMCefficiency:
         # remove trigger, it will be part of the efficiency selection for passing trigger
-        df = df.Filter("HLT_IsoTkMu24 || HLT_IsoMu24")
+        hltString="HLT_IsoTkMu24 || HLT_IsoMu24" if args.dataYear == 2016 else "HLT_IsoMu24"
+        df = df.Filter(hltString)
 
     if args.halfStat:
         df = df.Filter("event % 2 == 1") # test with odd/even events

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -203,7 +203,7 @@ def common_parser(for_reco_highPU=False):
         parser.add_argument("--noSmooth3dsf", dest="smooth3dsf", action='store_false', help="If true (defaul) use smooth 3D scale factors instead of the original 2D ones (but eff. systs are still obtained from 2D version)")
         parser.add_argument("--sf2DnoUt", action='store_true', help="Use older smooth 2D scale factors with no ut dependence")
         parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing") 
-
+        parser.add_argument("--dataYear", default=2016, type=int, help="year for which the analysis is performed")
     commonargs,_ = parser.parse_known_args()
 
     if for_reco_highPU:

--- a/wremnants/__init__.py
+++ b/wremnants/__init__.py
@@ -18,7 +18,7 @@ from .muon_efficiencies_binned_vqt import make_muon_efficiency_helpers_binned_vq
 from .muon_efficiencies_binned_vqt_integrated import make_muon_efficiency_helpers_binned_vqt_integrated
 from .muon_efficiencies_binned_vqt_real import make_muon_efficiency_helpers_binned_vqt_real
 from .qcdScaleByHelicity_helper import makeQCDScaleByHelicityHelper
-from .pileup import make_pileup_helper
+from .pileup import make_pileup_helper, make_pileup_helperRun2
 from .vertex import make_vertex_helper
 from .syst_tools import scale_helicity_hist_to_variations
 from .theory_tools import axis_helicity, scale_tensor_axes, define_prefsr_vars, moments_to_angular_coeffs

--- a/wremnants/datasets/datasetDict2018_v9.py
+++ b/wremnants/datasets/datasetDict2018_v9.py
@@ -1,0 +1,183 @@
+import copy
+from utilities import common
+
+lumicsv = f"{common.data_dir}/bylsoutput_2018.csv"
+lumijson = f"{common.data_dir}/Cert_314472-325175_13TeV_UL2018_Collisions18_HLT_IsoMu24_v_CustomJSON.txt"
+
+BR_TAUToMU = 0.1739
+BR_TAUToE = 0.1782
+xsec_ZmmPostVFP = 2001.9
+xsec_WpmunuPostVFP = 11765.9
+xsec_WmmunuPostVFP = 8703.87
+xsec_ZmmMass10to50PostVFP = 6997.0
+Z_TAU_TO_LEP_RATIO = (1.-(1. - BR_TAUToMU - BR_TAUToE)**2)
+
+#NOTES
+#BASE_PATH is /scratchnvme/wmass/NANOV9/postVFP (so 2018 BASE path is {BASE_PATH}/../y2018/) have to update at some point
+#ZtautauPostVFP sample is one available from centrl production, so 
+dataDictV9_2018 = {
+    'dataPostVFP' : { 
+        'filepaths' : [ "{BASE_PATH}/../y2018/SingleMuon/NanoV9Run2018A_TrackRefit722/*.root",
+                        "{BASE_PATH}/../y2018/SingleMuon/NanoV9Run2018B_TrackRefit722/*.root",
+                        "{BASE_PATH}/../y2018/SingleMuon/NanoV9Run2018B_TrackRefit722/*.root",
+                        "{BASE_PATH}/../y2018/SingleMuon/NanoV9Run2018D_TrackRefit722/*.root",                          
+                    ],
+        'group': "Data",
+        "lumicsv":lumicsv,
+        "lumijson":lumijson,
+        "das_name" : "private"
+    },
+    'ZmumuPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MC2018_2018test/230530_220228/*/*.root"],
+        'xsec' : xsec_ZmmPostVFP,
+        'group': "Zmumu",
+        "das_name" : "private"
+    },    
+    'DYJetsToMuMuMass10to50PostVFP' : {
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root",
+                       "{BASE_PATH}/../y2018/BKGV9/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1_ext1-v1/*/*.root"],
+        'xsec' : xsec_ZmmMass10to50PostVFP,
+        'group': "DYlowMass",
+        "das_name" : "/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1*v1/NANOAODSIM"
+    },
+    #'ZtautauPostVFP' : { #this sample needs to be produced
+    #    'filepaths' : ["{BASE_PATH}/../y2018/DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_massWgtFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/*/*.root"],
+    # At least one tau->e or mu decay, so everything that's not all other decays
+    #   'xsec' : xsec_ZmmPostVFP*Z_TAU_TO_LEP_RATIO,
+    #'group': "Ztautau",
+    #  'group': "DYlowMass",
+    #  "das_name" : "/DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_massWgtFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM"
+    #},
+
+    'WplusmunuPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MC2018_2018test/230530_220442/*/*.root"],
+        'xsec' : xsec_WpmunuPostVFP,
+        'group': "Wmunu",
+        "das_name" : "private"
+    },
+    'WminusmunuPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MC2018_2018test/230530_220636/*/*.root"],
+        'xsec' : xsec_WmmunuPostVFP,
+        'group': "Wmunu",
+        "das_name" : "private"
+    },
+    'WplustaunuPostVFP' : { 
+                         'filepaths' : 
+                         ["{BASE_PATH}/../y2018/WplusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/*.root",],
+                         'xsec' : BR_TAUToMU*xsec_WpmunuPostVFP,
+                         'group': "Wtaunu",
+                         "das_name" : "private"
+    },    
+    'WminustaunuPostVFP' : { 
+                         'filepaths' : 
+                         ["{BASE_PATH}/../y2018/WminusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/*.root"],
+                         'xsec' : BR_TAUToMU*xsec_WmmunuPostVFP,
+                         'group': "Wtaunu",
+                         "das_name" : "private"
+    },
+    'TTLeptonicPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 88.29,
+        'group' : "Top",
+        "das_name" : "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+
+    'TTSemileptonicPostVFP' : { ##could not copy full stat of this sample due to lack of storage 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 366.34,
+        'group' : "Top",
+        "das_name" : "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'SingleTschanLepDecaysPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 3.609,
+        'group' : "Top",
+        "das_name" : "/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'SingleTtWAntitopPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 19.55, # 35.85 * (1.0-((1-0.1086*3)*(1-0.1086*3))) = 19.5 pb
+        'group' : "Top",
+        "das_name" : "/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'SingleTtWTopPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 19.55,
+        'group' : "Top",
+        "das_name" : "/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'SingleTtchanAntitopPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 80.0,
+        'group' : "Top",
+        "das_name" : "/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'SingleTtchanTopPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 134.2,
+        'group' : "Top",
+        "das_name" : "/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },   
+    # inclusive samples, keep for reference
+    # 'WWPostVFP' : { 
+    #                 'filepaths' : 
+    #                 ["{BASE_PATH}/BKGV9/WW_TuneCP5_13TeV-pythia8/*.root"],
+    #                 'xsec' : 118.7,
+    #                 'group' : "Diboson",
+    # },
+    # 'WZPostVFP' : { 
+    #                 'filepaths' : 
+    #                 ["{BASE_PATH}/BKGV9/WZ_TuneCP5_13TeV-pythia8/*.root"],
+    #                 'xsec' : 47.026760,  # to check, taken from WZTo1L1Nu2Q dividing by BR: 10.71/(3*0.1086)/(1-3*0.033658-0.2)
+    #                 'group' : "Diboson",
+    # },
+    ##
+    'WWTo2L2NuPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/*/*.root"],
+        'xsec' : 12.6, # 118.7*0.1086*0.1086*9
+        'group' : "Diboson",
+        "das_name" : "/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM"
+    },
+    'WWTo1L1Nu2QPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 52.146, # 118.7*[(3*0.1086)*(1-3*0.1086)]*2 (2 is because one W or the other can go to Q)
+        'group' : "Diboson",
+        "das_name" : "/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'WZTo3LNuPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/*/*.root"],
+        'xsec' : 4.91, # 4.42965*1.109, 1.109 is the NLO to NNLO kfactor, for this one would need to make sure about the NLO XS, depends a lot on the dilepton mass cut
+        'group' : "Diboson",
+        "das_name" : "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM"
+    },
+    'WZTo2Q2LPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 5.4341, # 4.9*1.109
+        'group' : "Diboson",
+        "das_name" : "/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'WZTo1L1Nu2QPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 11.781, # 10.71*1.10
+        'group' : "Diboson",
+        "das_name" : "/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'ZZTo2L2NuPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 0.60,
+        'group' : "Diboson",
+        "das_name" : "/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    'ZZTo2Q2LPostVFP' : { 
+        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/*/*.root"],
+        'xsec' : 5.1,
+        'group' : "Diboson",
+        "das_name" : "/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
+    },
+    #'QCDmuEnrichPt15PostVFP' : { #Not copied
+    #    'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/*/*.root"],
+    #    'xsec' : 238800,
+    #    'group' : "QCD",
+    #    "das_name" : "/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM"
+    #}
+}

--- a/wremnants/datasets/dataset_tools.py
+++ b/wremnants/datasets/dataset_tools.py
@@ -11,6 +11,7 @@ from wremnants.datasets.datasetDict_v9 import dataDictV9
 from wremnants.datasets.datasetDict_v8 import dataDictV8
 from wremnants.datasets.datasetDict_gen import genDataDict
 from wremnants.datasets.datasetDict_lowPU import dataDictLowPU
+from wremnants.datasets.datasetDict2018_v9 import dataDictV9_2018
 
 logger = logging.child_logger(__name__)
 
@@ -93,7 +94,12 @@ def excludeProcs(excludes, datasets):
     else:
         return datasets
 
-def getDatasetDict(mode=None, nanoVersion="v9"):
+def getDatasetDict(mode=None, nanoVersion="v9", dataYear=2016):
+    if dataYear == 2018:
+        dataDict = dataDictV9_2018
+        logger.info('Using NanoAOD V9 for 2018')
+        return dataDict
+
     if mode == "lowPU":
         return dataDictLowPU
 
@@ -143,12 +149,12 @@ def is_zombie(file_path):
         return True
 
 def getDatasets(maxFiles=-1, filt=None, excl=None, mode=None, base_path=None, nanoVersion="v9", 
-                data_tag="TrackFitV722_NanoProdv2", mc_tag="TrackFitV718_NanoProdv1", oneMCfileEveryN=None, checkFileForZombie=False):
+                data_tag="TrackFitV722_NanoProdv2", mc_tag="TrackFitV718_NanoProdv1", oneMCfileEveryN=None, checkFileForZombie=False, dataYear=2016):
     if not base_path:
         base_path = getDataPath(mode)
     logger.info(f"Loading 2016 samples from {base_path}.")
 
-    dataDict = getDatasetDict(mode, nanoVersion)
+    dataDict = getDatasetDict(mode, nanoVersion, dataYear)
 
     narf_datasets = []
     for sample,info in dataDict.items():

--- a/wremnants/vertex.py
+++ b/wremnants/vertex.py
@@ -5,8 +5,11 @@ import narf
 import numpy as np
 import boost_histogram as bh
 from utilities import common
+from utilities import common, logging
 
 narf.clingutils.Declare('#include "vertex.h"')
+
+logger = logging.child_logger(__name__)
 
 data_dir = common.data_dir
 
@@ -15,8 +18,11 @@ def make_vertex_helper(era = None,
 
     eradict = { "2016PreVFP" :  "BtoF",
                 "2016PostVFP" : "GtoH",
+                "2017" : "2017",
+                "2018" : "2018"
     }
-    
+
+    logger.debug(f"vertex.py: will read weight_vertexZ_pileup_{eradict[era]} from {filename}")
     fmc = ROOT.TFile.Open(filename)
     mchist = fmc.Get(f"weight_vertexZ_pileup_{eradict[era]}")
     mchist.SetDirectory(0)


### PR DESCRIPTION
- PR includes changes to dataset tools to read 2018 files
- Json, PU & vtx weight files provided by @tanmayvb added.
- puhelper updated(though this could done in a better way in future)
- vertex helper updated.
- mw histomaker updated.

# Note
Need to disable calibrations. For tests-

```
python WRemnants/scripts/histmakers/mw_with_mu_eta_pt.py -v 4  --noRecoil --onlyMainHistograms --muonCorrMC none --muonCorrData none --noScaleFactors --dataYear 2018  --maxFiles=2
```
