### PR TITLE
Misc developments for full Run 2

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -289,10 +289,11 @@ def build_graph(df, dataset):
     df = muon_selections.veto_electrons(df)
     df = muon_selections.apply_met_filters(df)
     if args.makeMCefficiency:
-        df = df.Define("GoodTrigObjs", "wrem::goodMuonTriggerCandidate(TrigObj_id,TrigObj_filterBits)")
-        df = df.Define("passTrigger","(HLT_IsoTkMu24 || HLT_IsoMu24) && wrem::hasTriggerMatch(goodMuons_eta0,goodMuons_phi0,TrigObj_eta[GoodTrigObjs],TrigObj_phi[GoodTrigObjs])")
+        df = df.Define("GoodTrigObjs", f"wrem::goodMuonTriggerCandidate(TrigObj_id,TrigObj_filterBits, \"{era}\")")
+        hltString="HLT_IsoTkMu24 || HLT_IsoMu24" if era == "2016PostVFP" else "HLT_IsoMu24"
+        df = df.Define("passTrigger", f"{hltString} && wrem::hasTriggerMatch(goodMuons_eta0,goodMuons_phi0,TrigObj_eta[GoodTrigObjs],TrigObj_phi[GoodTrigObjs])")
     else:
-        df = muon_selections.apply_triggermatching_muon(df, dataset, "goodMuons_eta0", "goodMuons_phi0")
+        df = muon_selections.apply_triggermatching_muon(df, dataset, "goodMuons_eta0", "goodMuons_phi0", era=era)
 
     if isWorZ:
         df = muon_validation.define_cvh_reco_muon_kinematics(df)

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -203,9 +203,9 @@ def build_graph(df, dataset):
     df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")
 
     if args.useDileptonTriggerSelection:
-        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", "nonTrigMuons_eta0", "nonTrigMuons_phi0")
+        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", "nonTrigMuons_eta0", "nonTrigMuons_phi0", era=era)
     else:
-        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0")
+        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", era=era)
 
     df = df.Define("ptll", "ll_mom4.pt()")
     df = df.Define("yll", "ll_mom4.Rapidity()")

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -171,7 +171,7 @@ def build_graph(df, dataset):
     df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons")
     df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")
 
-    df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0")
+    df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", era=era)
 
     if dataset.is_data:
         df = df.DefinePerSample("nominal_weight", "1.0")

--- a/wremnants/datasets/datasetDict2018_v9.py
+++ b/wremnants/datasets/datasetDict2018_v9.py
@@ -26,8 +26,7 @@ dataDictV9_2018 = {
         "das_name" : "private"
     },    
     'DYJetsToMuMuMass10to50PostVFP' : {
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos",
-                       "{BASE_PATH}/../y2018/BKGV9/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1_ext1-v1/*/*.root"],
+        'filepaths' : ["{BASE_PATH}/../y2018/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : common.xsec_ZmmMass10to50PostVFP,
         'group': "DYlowMass",
         "das_name" : "/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1*v1/NANOAODSIM"
@@ -55,57 +54,57 @@ dataDictV9_2018 = {
     },
     'WplustaunuPostVFP' : { 
                          'filepaths' : 
-                         ["{BASE_PATH}/../y2018/WplusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos",],
+                         ["{BASE_PATH}/../y2018/WplusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MC2018_{NANO_PROD_TAG}",],
                          'xsec' : common.BR_TAUToMU*common.xsec_WpmunuPostVFP,
                          'group': "Wtaunu",
                          "das_name" : "private"
     },    
     'WminustaunuPostVFP' : { 
                          'filepaths' : 
-                         ["{BASE_PATH}/../y2018/WminusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos"],
+                         ["{BASE_PATH}/../y2018/WminusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MC2018_{NANO_PROD_TAG}"],
                          'xsec' : common.BR_TAUToMU*common.xsec_WmmunuPostVFP,
                          'group': "Wtaunu",
                          "das_name" : "private"
     },
     'TTLeptonicPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 88.29,
         'group' : "Top",
         "das_name" : "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
 
     'TTSemileptonicPostVFP' : { ##could not copy full stat of this sample due to lack of storage 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 366.34,
         'group' : "Top",
         "das_name" : "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'SingleTschanLepDecaysPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 3.609,
         'group' : "Top",
         "das_name" : "/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'SingleTtWAntitopPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 19.55, # 35.85 * (1.0-((1-0.1086*3)*(1-0.1086*3))) = 19.5 pb
         'group' : "Top",
         "das_name" : "/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'SingleTtWTopPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 19.55,
         'group' : "Top",
         "das_name" : "/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'SingleTtchanAntitopPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 80.0,
         'group' : "Top",
         "das_name" : "/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'SingleTtchanTopPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 134.2,
         'group' : "Top",
         "das_name" : "/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
@@ -113,61 +112,61 @@ dataDictV9_2018 = {
     # inclusive samples, keep for reference
     # 'WWPostVFP' : { 
     #                 'filepaths' : 
-    #                 ["{BASE_PATH}/BKGV9/WW_TuneCP5_13TeV-pythia8/*.root"],
+    #                 ["{BASE_PATH}/WW_TuneCP5_13TeV-pythia8/*.root/NanoV9MC2018_{NANO_PROD_TAG}"],
     #                 'xsec' : 118.7,
     #                 'group' : "Diboson",
     # },
     # 'WZPostVFP' : { 
     #                 'filepaths' : 
-    #                 ["{BASE_PATH}/BKGV9/WZ_TuneCP5_13TeV-pythia8/*.root"],
+    #                 ["{BASE_PATH}/WZ_TuneCP5_13TeV-pythia8/*.root/NanoV9MC2018_{NANO_PROD_TAG}"],
     #                 'xsec' : 47.026760,  # to check, taken from WZTo1L1Nu2Q dividing by BR: 10.71/(3*0.1086)/(1-3*0.033658-0.2)
     #                 'group' : "Diboson",
     # },
     ##
     'WWTo2L2NuPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 12.6, # 118.7*0.1086*0.1086*9
         'group' : "Diboson",
         "das_name" : "/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM"
     },
     'WWTo1L1Nu2QPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 52.146, # 118.7*[(3*0.1086)*(1-3*0.1086)]*2 (2 is because one W or the other can go to Q)
         'group' : "Diboson",
         "das_name" : "/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'WZTo3LNuPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 4.91, # 4.42965*1.109, 1.109 is the NLO to NNLO kfactor, for this one would need to make sure about the NLO XS, depends a lot on the dilepton mass cut
         'group' : "Diboson",
         "das_name" : "/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM"
     },
     'WZTo2Q2LPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 5.4341, # 4.9*1.109
         'group' : "Diboson",
         "das_name" : "/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'WZTo1L1Nu2QPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 11.781, # 10.71*1.10
         'group' : "Diboson",
         "das_name" : "/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'ZZTo2L2NuPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 0.60,
         'group' : "Diboson",
         "das_name" : "/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     'ZZTo2Q2LPostVFP' : { 
-        'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        'filepaths' : ["{BASE_PATH}/../y2018/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MC2018_{NANO_PROD_TAG}"],
         'xsec' : 5.1,
         'group' : "Diboson",
         "das_name" : "/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM"
     },
     #'QCDmuEnrichPt15PostVFP' : { #Not copied
-    #    'filepaths' : ["{BASE_PATH}/../y2018/BKGV9/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/*/*.root"],
+    #    'filepaths' : ["{BASE_PATH}/../y2018/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/*/*.root/NanoV9MC2018_{NANO_PROD_TAG}"],
     #    'xsec' : 238800,
     #    'group' : "QCD",
     #    "das_name" : "/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM"

--- a/wremnants/datasets/dataset_tools.py
+++ b/wremnants/datasets/dataset_tools.py
@@ -198,7 +198,8 @@ def getDataPath(mode=None):
     elif hostname == "cmsanalysis.pi.infn.it":
         # NOTE: If anyone wants to run lowpu analysis at Pisa they'd probably want a different path
         base_path = "/scratchnvme/wmass/NANOV9/postVFP"
-
+    elif hostname == "cmsasymow.pi.infn.it":
+        base_path = "/scratch/wmass/y2016"
     return base_path
 
 def is_zombie(file_path):

--- a/wremnants/include/utils.h
+++ b/wremnants/include/utils.h
@@ -118,14 +118,15 @@ Vec_i cleanJetsFromLeptons(const Vec_f& Jet_eta, const Vec_f& Jet_phi, const Vec
 }
     
     
-Vec_i goodMuonTriggerCandidate(const Vec_i& TrigObj_id, const Vec_f& TrigObj_pt, const Vec_f& TrigObj_l1pt, const Vec_f& TrigObj_l2pt, const Vec_i& TrigObj_filterBits) {
-
+Vec_i goodMuonTriggerCandidate(const Vec_i& TrigObj_id, const Vec_f& TrigObj_pt, const Vec_f& TrigObj_l1pt, const Vec_f& TrigObj_l2pt, const Vec_i& TrigObj_filterBits, const string&  era = "2016PostVFP") {
+  
    Vec_i res(TrigObj_id.size(), 0); // initialize to 0
    for (unsigned int i = 0; i < res.size(); ++i) {
        if (TrigObj_id[i]  != 13 ) continue;
        if (TrigObj_pt[i]   < 24.) continue;
        if (TrigObj_l1pt[i] < 22.) continue;
-       if (! (( TrigObj_filterBits[i] & 8) || (TrigObj_l2pt[i] > 10. && (TrigObj_filterBits[i] & 2) )) ) continue;
+       if (era == "2016PostVFP" && (! (( TrigObj_filterBits[i] & 8) || (TrigObj_l2pt[i] > 10. && (TrigObj_filterBits[i] & 2) ))) ) continue;
+       if (era != "2016PostVFP" && (! (TrigObj_l2pt[i] > 10. && (TrigObj_filterBits[i] & 2) )) ) continue;
        res[i] = 1;
    }
    // res will be goodTrigObjs in RDF
@@ -134,12 +135,13 @@ Vec_i goodMuonTriggerCandidate(const Vec_i& TrigObj_id, const Vec_f& TrigObj_pt,
 }
 
 // new overloaded function to be used with new ntuples having additional trigger bits
-Vec_i goodMuonTriggerCandidate(const Vec_i& TrigObj_id, const Vec_i& TrigObj_filterBits) {
+Vec_i goodMuonTriggerCandidate(const Vec_i& TrigObj_id, const Vec_i& TrigObj_filterBits, const string& era = "2016PostVFP") {
 
-    Vec_i res(TrigObj_id.size(), 0); // initialize to 0
+  Vec_i res(TrigObj_id.size(), 0); // initialize to 0
     for (unsigned int i = 0; i < res.size(); ++i) {
         if (TrigObj_id[i]  != 13 ) continue;
-        if (! ( (TrigObj_filterBits[i] & 16) || (TrigObj_filterBits[i] & 32) ) ) continue;
+        if (era == "2016PostVFP" && (! ( (TrigObj_filterBits[i] & 16) || (TrigObj_filterBits[i] & 32) )) ) continue;
+	if (era != "2016PostVFP" && (! (TrigObj_filterBits[i] & 4096) ) ) continue;//add 8192 later?
         res[i] = 1;
     }
     return res;

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -97,7 +97,7 @@ def select_z_candidate(df, mass_min=60, mass_max=120):
 
     return df
 
-def apply_triggermatching_muon(df, dataset, muon_eta, muon_phi, otherMuon_eta=None, otherMuon_phi=None):
+def apply_triggermatching_muon(df, dataset, muon_eta, muon_phi, otherMuon_eta=None, otherMuon_phi=None, era = "2016PostVFP"):
     df = df.Define("goodTrigObjs", "wrem::goodMuonTriggerCandidate(TrigObj_id,TrigObj_filterBits)")
     if otherMuon_eta is not None:
         # implement OR of trigger matching condition (for dilepton), also create corresponding flags


### PR DESCRIPTION
## In this PR,
- Allow wremnant to run on new machine (as usual, the default path is set for 2016, 2018 paths are relative to that)
- Add custom BKG samples 
- Improve a bit the trigger object matching criteria - for now IsoMu24 is added, (do we add IsoMu27 for later)

## Checks done
mw, mz-dilepton, mz-wlike histomakers run for 2016 & 2018.

I have also checked mw histomaker with ```--makeMCefficiency``` option running on WplusMunu sample for 2016 & 2018.